### PR TITLE
fix: FileNotFoundException from loading material texture

### DIFF
--- a/neoforge/src/main/java/com/github/razorplay01/ismah/neoforge/mixin/ItemInHandRendererMixin.java
+++ b/neoforge/src/main/java/com/github/razorplay01/ismah/neoforge/mixin/ItemInHandRendererMixin.java
@@ -86,6 +86,10 @@ public class ItemInHandRendererMixin {
 
         for (ArmorMaterial.Layer layer : armorMaterial.layers()) {
             ResourceLocation texture = layer.texture(false);
+            if (!textureExists(texture)) {
+                continue;
+            }
+
             int layerColor = layer.dyeable() ? color : -1;
             VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderType.armorCutoutNoCull(texture));
             armorArm.render(matrices, vertexConsumer, light, OverlayTexture.NO_OVERLAY, layerColor);
@@ -119,5 +123,10 @@ public class ItemInHandRendererMixin {
             VertexConsumer glintConsumer = vertexConsumers.getBuffer(RenderType.armorEntityGlint());
             armorArm.render(matrices, glintConsumer, light, OverlayTexture.NO_OVERLAY);
         }
+    }
+
+    @Unique
+    private boolean textureExists(ResourceLocation texture) {
+        return MINECRAFT_CLIENT.getResourceManager().getResource(texture).isPresent();
     }
 }


### PR DESCRIPTION
Mods may not have this texture present.
It's better to then not render for custom models, rather than throwing an error or for some people crashing.
Optionally it may be good to add a warning
Might resolve [issue 11](https://github.com/RazorPlay01/I-See-My-Armored-Hand/issues/11)